### PR TITLE
Fixed return() in test failing

### DIFF
--- a/packages/protocol/test/sablier/behaviors/Withdraw.behavior.js
+++ b/packages/protocol/test/sablier/behaviors/Withdraw.behavior.js
@@ -71,7 +71,9 @@ function shouldBehaveLikeERC1620Withdraw(alice, bob, eve) {
               await this.sablier.withdraw(streamId, amount, opts);
               const newBalance = await this.sablier.balanceOf(streamId, recipient);
               balance.should.bignumber.satisfy(function(num) {
-                return num.isEqualTo(newBalance.plus(amount)) || num.isEqualTo(newBalance.plus(amount).plus(ONE_UNIT));
+                return (
+                  num.isEqualTo(newBalance.plus(amount)) || num.isEqualTo(newBalance.plus(amount).plus(ONE_UNIT))
+                );
               });
             });
           });


### PR DESCRIPTION
I was running yarn coverage and tests failed. Found a typo in a test and fixed it.
 
![Screenshot from 2019-08-29 18-06-47](https://user-images.githubusercontent.com/54679443/63960398-ec8e9200-ca7d-11e9-81d0-e57e9afa1e44.png)
