### PR TITLE
fix(shared-contracts): remove renouncePauser

### DIFF
--- a/packages/shared-contracts/lifecycle/PauserRoleWithoutRenounce.sol
+++ b/packages/shared-contracts/lifecycle/PauserRoleWithoutRenounce.sol
@@ -39,10 +39,6 @@ contract PauserRoleWithoutRenounce is Initializable, Context {
         _addPauser(account);
     }
 
-    function renouncePauser() public {
-        _removePauser(_msgSender());
-    }
-
     function _addPauser(address account) internal {
         _pausers.add(account);
         emit PauserAdded(account);


### PR DESCRIPTION
Remove the `renouncePauser` function from the `PausableWithoutRenounce` contract.

(I know)