### PR TITLE
chore(eslint-config): update package version to 1.0.1

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sablier/eslint-config",
   "description": "Eslint config to be shared across Sablier projects and packages",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Sablier",
     "email": "paul@sablier.app",


### PR DESCRIPTION
The version is erroneously set to "1.0.0", even if on npm the latest version (and the one for which the code corresponds to) is "1.0.1".