### PR TITLE
fix payroll tests not testing employee caller

### DIFF
--- a/packages/payroll/test/payroll/effects/salary/CancelSalary.js
+++ b/packages/payroll/test/payroll/effects/salary/CancelSalary.js
@@ -78,7 +78,7 @@ function shouldBehaveLikeCancelSalary(alice, bob, eve) {
 
     describe("when the caller is the employee", function() {
       beforeEach(async function() {
-        this.opts = { from: this.company };
+        this.opts = { from: this.employee };
       });
 
       runTests();


### PR DESCRIPTION
In CancelSalary.js the tests are run twice from the perspective of the company and not from the perspective of the employee.